### PR TITLE
Agrega test e2e para las alertas

### DIFF
--- a/tests/e2e/specs/income.spec.js
+++ b/tests/e2e/specs/income.spec.js
@@ -28,4 +28,31 @@ describe('Ingresos Test', () => {
 
         cy.get('[data-testid=movement]').should('have.length', 5);
     });
+
+    it('Deberia aparecer una alerta al crear un nuevo ingreso', () => {
+        cy.visit('/income');
+
+        cy.get('input[name=date]').type('2021-04-26');
+        cy.get('input[name=category]').type('Bono');
+        cy.get('input[name=amount]').type('100000');
+        cy.contains('Guardar').click();
+        cy.on('window:alert',(text)=>{
+            expect(text).to.contains('');
+        });
+        
+    });
+
+    it('Deberia aparecer una alerta al editar un ingreso', () => {
+        cy.visit('/income');
+
+        cy.get('[data-testid=movement]')
+            .find('button')
+            .contains('editar')
+            .click();
+
+        cy.contains('Guardar').click();
+        cy.on('window:alert',(text)=>{
+            expect(text).to.contains('');
+        });
+    });
 });


### PR DESCRIPTION
Buenas, hice dos test e2e para las alertas. Uno para cuando se crea un movimiento y uno para cuando se edita. Sólo encontré ejemplos usando window:alert como evento, asi que lo que testea es que el alert tenga un mensaje.