### PR TITLE
Test de montos con decimales

### DIFF
--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -12,3 +12,14 @@ test('Should convert undefined into ""', async () => {
     expect(monefy(undefined)).toBe('');
 });
 
+test('Should convert 200.5 into "200,50"', async () => {
+    expect(monefy(200.5)).toBe('200,50');
+});
+
+test('Should convert 2000.5 into "2.000,50"', async () => {
+    expect(monefy(2000.5)).toBe('2.000,50');
+});
+
+test('Should convert 2000.555 into "2.000,55"', async () => {
+    expect(monefy(2000.555)).toBe('2.000,55');
+});


### PR DESCRIPTION
Para testear este bug extendí el test unitario que ya habia de la función monefy para los casos de números con coma con 1 y mas de 2 decimales para testear que no se rompa el formato y que mantenga siempre 2 decimales.  